### PR TITLE
chore: upgrade actions/create-github-app-token to v3, use client-id

### DIFF
--- a/.github/workflows/migrate-work-items.yml
+++ b/.github/workflows/migrate-work-items.yml
@@ -68,10 +68,10 @@ jobs:
       - name: get gh version
         run: gh --version
 
-      # - uses: actions/create-github-app-token@v1
+      # - uses: actions/create-github-app-token@v3
       #   id: app-token
       #   with:
-      #     app-id: 179484 # work-item-migrator
+      #     client-id: 179484 # work-item-migrator
       #     private-key: ${{ secrets.PRIVATE_KEY }}
       #     owner: ${{ github.repository_owner }}
       


### PR DESCRIPTION
## Summary

Upgrades `actions/create-github-app-token` to `@v3` and migrates from the deprecated `app-id` input to `client-id`.

### Changes
- ⬆️ Updated `actions/create-github-app-token` to `@v3`
- 🔄 Renamed input from `app-id` to `client-id` ([v3 changelog](https://github.com/actions/create-github-app-token/releases/tag/v3.0.0))

### ⚠️ Action Required
Verify the `APP_ID` variable contains a valid Client ID (`Iv...`) before merging.